### PR TITLE
Respect user specified strain for single phase input (patch issue #11)

### DIFF
--- a/polyxsim/check_input.py
+++ b/polyxsim/check_input.py
@@ -385,9 +385,8 @@ class parse_input:
                 for phase in phase_list:
                     self.param['gen_size_phase_%i' %phase] = copy(self.param['gen_size'])
             else:
-                phase = 0 
-                self.param['gen_size_phase_%i' %phase] = copy(self.param['gen_size'])
-                
+                self.param['gen_size_phase_0'] = copy(self.param['gen_size'])
+
         if len(phase_list_gen_eps) != 0:
 #             assert len(phase_list_gen_eps) == no_phases, \
 #                 'Input number of structural phases does not agree with number\n' +\
@@ -409,12 +408,7 @@ class parse_input:
                 for phase in phase_list:
                     self.param['gen_eps_phase_%i' %phase] = copy(self.param['gen_eps'])
             else:
-                phase = 0 
-                # If strain is not provided and no generation of strains have be asked for
-                # "set" all eps to zero. 
-                if self.param['gen_eps'][0] == 0:
-                    self.param['gen_eps'] = [1, 0.0, 0.0, 0.0, 0.0]
-                self.param['gen_eps_phase_%i' %phase] = copy(self.param['gen_eps'])
+                self.param['gen_eps_phase_0'] = copy(self.param['gen_eps'])
         if self.param['gen_phase'][0] != 0:
 #             assert len(self.param['gen_phase'][1:]) == no_phases*2, 'Missing info for  -  gen_phase'
             if len(self.param['gen_phase'][1:]) != no_phases*2:
@@ -463,7 +457,6 @@ class parse_input:
                 elif 'phase' in item[:5]:
                     grain_list_phase.append(eval(item.split('_grains_')[1]))
                     self.param['no_grains_phase_%i' %self.param[item]] += 1
-
 #assert that the number of grains in all match 
 
         sum_of_grains = 0
@@ -488,6 +481,8 @@ class parse_input:
         grain_list_eps.sort()
         grain_list_size.sort()
         grain_list_phase.sort()
+
+
         if len(grain_list_U) != 0 and self.param['gen_U'] == 0:
 #             assert len(grain_list_U) == no_grains, \
 #                 'Input number of grains does not agree with number\n' +\
@@ -613,15 +608,30 @@ class parse_input:
         if len(grain_list_pos) == 0 and self.param['gen_pos'][0] == 0:
             self.errors['grain_list_gen_pos'] = \
                 'Information on position generation missing'
-# Not used anymore as zero strains are given if not strains are provide 
-# and no gen_eps's are given. Might be used to write warnings later.
-#        if len(grain_list_eps) == 0 and self.param['gen_eps'][0] == 0:
-#            self.errors['grain_list_gen_eps'] = \
-#                'Information on strain tensor generation missing'
+        if len(grain_list_eps) == 0 and self.param['gen_eps'][0] == 0:
+            self.errors['grain_list_gen_eps'] = \
+               'Information on strain tensor generation missing'
         if len(grain_list_size) == 0 and self.param['gen_size'][0] == 0:
             self.errors['grain_list_gen_size'] = \
                 'Information on grain size generation missing'
-			
+
+        # The user should make a decision, either things are generated randomly, or they are provided
+        # specifically. .inp files with generation toogled to "on" and specified grain properties provided
+        # at the same time should be rejected.
+        if len(grain_list_U) != 0 and self.param['gen_U'] == 1:
+            self.errors['grain_list_gen_U'] = \
+                'grain U were provided, but gen_U is also set to true.'
+        if len(grain_list_pos) != 0 and self.param['gen_pos'][0] == 1:
+            self.errors['grain_list_gen_pos'] = \
+                'grain positions were provided, but gen_pos is also set to true.'
+        if len(grain_list_eps) != 0 and self.param['gen_eps'][0] == 1:
+            self.errors['grain_list_gen_eps'] = \
+               'grain strains were provided, but gen_eps is also set to true.'
+        if len(grain_list_size) != 0 and self.param['gen_size'][0] == 1:
+            self.errors['grain_list_gen_size'] = \
+                'grain sizes were provided, but gen_size is also set to true.'
+
+                
 #If no structure file is given - unit_cel should be               
         if len(phase_list) == 0:
             # This is a monophase simulation probably using the "old" keywords

--- a/test/simul_single_phase.inp
+++ b/test/simul_single_phase.inp
@@ -1,0 +1,58 @@
+### Instrumental
+beamflux 1e15
+wavelength  0.5092836 # in angstrom
+distance  135.00			# sample-detector distance (mm)
+dety_center  521.5				# beamcenter, y in pixel coordinatees
+detz_center  531.5				# beamcenter, z in pixel coordinatees
+y_size  0.0936   # Pixel size y (mm)
+z_size  0.0962   # Pixel size z (mm)
+dety_size  1024.0     # detector y size (pixels)
+detz_size  1024.0     # detector z size (pixels)
+tilt_x    0.0        # detector tilt counterclockwise around lab x axis in rad
+tilt_y    -0.1        # detector tilt counterclockwise around lab y axis in rad
+tilt_z    0.2       # detector tilt counterclockwise around lab z axis in rad
+omega_start  -90.0   # Minimum Omega in range of interest (in deg)
+omega_end  -50.0      # Maximum Omega in range of interest (in deg)
+omega_step  0.5      # Omega step size (in deg)
+omega_sign  1        # Sign of omega rotation
+beampol_factor  1    # Polarisation factor
+beampol_direct  0    # Polarisation direction
+#theta_min  0                # Minimum theta angle for reflection generation
+#theta_max  15               # Maximum theta angle for reflection generation
+o11   1              # Orientation matrix of detector
+o12   0              # [[o11,o12]
+o21   0              #  [o21,o22]]
+o22  -1              #
+
+### Grains
+no_grains  2
+
+gen_U 0        # generate grain orientations (1=on, 0=off)
+gen_pos 1 1     # generate grain positions (1=on, 0=off); (1=random, 0=(0,0,0)
+gen_eps 0 0 0 0 0 # generate strain tensors (1=on, 0=off); [mean (diag) spread (diag) mean (off-diag) spread (off-diag)]
+gen_size 1 0.05 0.01 0.25 # generate grain size (1=on, 0=off); [mean, min, max]
+sample_xyz 0.3 0.3 0.3  # sample size in mm
+
+U_grains_1 -0.888246 0.411253 -0.204671 -0.201101 -0.748709 -0.631659 -0.413011 -0.519909 0.747741
+U_grains_2 -0.158282 -0.986955 0.029458 -0.929214 0.158978 0.333597 -0.333929 0.025430 -0.942255
+
+eps_grains_1 -0.001294 4.4e-05 -0.00111 0.00259 -0.000228 -0.000491
+eps_grains_2 -0.001323 -4.9e-05 -0.001095 0.002575 -0.000318 -0.000453
+
+### Structural
+structure_file 'oPPA.cif'
+
+### Files
+direc  'simul'
+stem 'monoclinic'
+output '.flt' '.gve' '.ubi' '.par' '.edf'
+
+### Images
+make_image 0
+noise 1            # put on noise if different from 0, default no noise
+psf 1              # spread of Gaussian point spread function (detector)
+		   # corresponds roughly to the number of affected pixels on either side
+peakshape 1 2 0.5  # type, spread (in pixels from the central pixel), (spread in omega for type=1)
+		   # type=0 spike, type=1 2D Gaussian
+bg 20              # background counts
+spatial 'spatial1k.spline'

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -16,6 +16,16 @@ class test_input(unittest.TestCase):
         myinput.read()
         myinput.check()
         myinput.initialize()
+    def test_single_phase(self):
+        myinput = check_input.parse_input(input_file='simul_single_phase.inp')
+        myinput.read()
+        gen_eps_before_check = myinput.param['gen_eps'].copy()
+        myinput.check()
+        myinput.initialize()
+        gen_eps_before_after_check = myinput.param['gen_eps'].copy()
+        for gen_eps1,gen_eps2 in zip(gen_eps_before_check, gen_eps_before_after_check):
+            self.assertEqual(gen_eps1, gen_eps2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Patch for issue #11 - 

If a single phase simulation is run, the strains defined by user was not respected prior to this patch.

Essentially PolyXsim was trying to set the strains to zeros - **if gen_eps is "of" and no tensors are provided**
A bug in this implementation made gen_eps toogle to "on" during input checking in [``check_input.py line 416``](https://github.com/FABLE-3DXRD/PolyXSim/blob/2a6a4826803a9aae52800c5f2794a4aa7addd321/polyxsim/check_input.py#L416) even though strains were provided.

IMHO: *If the user want to specify zero strain for all grains, then they may simply set "gen_eps 0 0 0 0 0" in their .inp file and not provide any tensors. PolyXSim should not allow the user to specify nonsensical .inp files. I.e if strains are provided, gen_eps must be "of", or else and error is raised. Likewise, if strains are not provided then gen_eps must be "on", or else an error is raise.*

This patch implements this behaviour. (and a unit test is provided to ensure the specific bug with the strains is removed.)

Cheers
Axel
