### PR TITLE
Make U matrices orthonormal

### DIFF
--- a/polyxsim/check_input.py
+++ b/polyxsim/check_input.py
@@ -34,7 +34,7 @@ def R2U( rot ):
     # q . s^1 . s .r == q.r, but s^1 == s, so:
     U = q.dot( s )
     if not n.allclose( U.astype(n.float32),
-                       rot.astype(n.float32) ):
+                       rot.astype(n.float32), atol=1e-4 ):
         warnings.warn(repr(rot) + '\n was rounded to \n' + repr(U))
     return U
 

--- a/polyxsim/check_input.py
+++ b/polyxsim/check_input.py
@@ -21,6 +21,23 @@ def interrupt(killfile):
     if killfile is not None and os.path.exists(killfile):
         raise KeyboardInterrupt
 
+import warnings
+def R2U( rot ):
+    """
+    R is an input Rotation matrix with finite precision
+    Try to locate the nearest orthonormal matrix and return it
+    """
+    # q is orthonormal. Ideally, r will be the identity matrix.
+    q, r = n.linalg.qr( n.asarray( rot ).astype( float ) )
+    # ... but usually signs are flipped. So here is the sign matrix.
+    s = n.diag( n.sign ( n.diag( r ) ) )
+    # q . s^1 . s .r == q.r, but s^1 == s, so:
+    U = q.dot( s )
+    if not n.allclose( U.astype(n.float32),
+                       rot.astype(n.float32) ):
+        warnings.warn(repr(rot) + '\n was rounded to \n' + repr(U))
+    return U
+
 
 class parse_input:
     def __init__(self,input_file = None):
@@ -239,6 +256,7 @@ class parse_input:
                         else:
                             self.param[key] = n.array(self.param[key])
                             self.param[key].shape = (3,3)
+                            self.param[key] = R2U( self.param[key] )
                     else:
                         #assert val.shape == (3,3), 'Wrong number of arguments for %s' %key
                         if  val.shape != (3,3): 

--- a/polyxsim/make_imagestack.py
+++ b/polyxsim/make_imagestack.py
@@ -261,7 +261,7 @@ class make_image:
         no_frames = len(self.graindata.frameinfo)
         print('\nGenerating ', no_frames, 'frames')
         for frame_no in self.frames:
-            t1 = time.clock()
+            t1 = time.time()
 
             frame = self.frames[frame_no].toarray()
             if self.graindata.param['bg'] > 0:
@@ -293,7 +293,7 @@ class make_image:
             self.write_tif(i,frame)
         if '.tif16bit' in self.graindata.param['output']:
             self.write_tif16bit(i,frame)
-        print('\rDone frame %i took %8f s' %(frame_no+1,time.clock()-t1), end=' ')
+        print('\rDone frame %i took %8f s' %(frame_no+1,time.time()-t1), end=' ')
         sys.stdout.flush()
                 
     def write_edf(self,framenumber,frame,usegzip=False):

--- a/scripts/overlaps.py
+++ b/scripts/overlaps.py
@@ -49,11 +49,11 @@ class determine_overlap:
         nover=zeros((nrefl))
         print('Ready to compare all %i reflections' %nrefl)
         print('')
-        t1 = time.clock()
+        t1 = time.time()
         for i in range(1,nrefl):
 #            if i%1000 == 0:
 #                print 'Comparing reflection %i' %i
-            t2 = time.clock()-t1
+            t2 = time.time()-t1
             print('\rCompared %4.1f pct in %5.1f sec' %(100.*i/nrefl,t2), end=' ')                        
             sys.stdout.flush()
 


### PR DESCRIPTION
This fixes a couple of time.clock calls and avoids the U matrix checks in xfab by looking for an orthogonal U matrix.

The problem is that the "U" matrices in text input files are not exactly orthonormal and so xfab u_to_euler complains. Probably they should be made orthonormal so that things like strain simulation will get done properly. 

@osholm : if I don't hear from you then I assume this is OK to merge? It should print a warning if there is a difference of more than 1e-4 on U matrices.